### PR TITLE
Bump `1.1.1` => `2.0.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "less-cache",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "less-cache",
-      "version": "1.1.1",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "fs-plus": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "less-cache",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Less compile cache",
   "main": "./src/less-cache",
   "scripts": {


### PR DESCRIPTION
Bumps the version of this package in preparation for a new release.

I'm bumping the major version of this package, since the version of `less` being used internally has breaking changes since it's last release, which means so does this.