### PR TITLE
Restore support for inline JavaScript in Less

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "less-cache",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "less-cache",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "fs-plus": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "less-cache",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Less compile cache",
   "main": "./src/less-cache",
   "scripts": {

--- a/spec/fixtures/with-js.less
+++ b/spec/fixtures/with-js.less
@@ -1,0 +1,8 @@
+.p(@foo) {
+  @value: ~`@{@foo} + 'px'`;
+  div {
+    padding: @value;
+  }
+}
+
+.p(10);

--- a/spec/less-cache-spec.coffee
+++ b/spec/less-cache-spec.coffee
@@ -55,6 +55,26 @@ describe "LessCache", ->
 
       """
 
+    it "tolerates inline JavaScript", ->
+      filePath = join(fixturesDir, 'with-js.less')
+      lessWithJs = """
+      .p(@foo) {
+        @value: ~`@{foo} + 'px'`;
+        div {
+          padding: @value;
+        }
+      }
+
+      .p(10);
+      """
+      css = cache.cssForFile(filePath, lessWithJs)
+      expect(css).toBe """
+        div {
+          padding: 10px;
+        }
+
+      """
+
   describe "::readFileSync(filePath)", ->
     [css] = []
 

--- a/src/less-cache.js
+++ b/src/less-cache.js
@@ -253,7 +253,12 @@ class LessCache {
 
   parseLess(filePath, contents) {
     let css = null;
-    const options = {filename: filePath, syncImport: true, paths: this.importPaths};
+    const options = {
+      filename: filePath,
+      syncImport: true,
+      paths: this.importPaths,
+      javascriptEnabled: true
+    };
     // load or assign less and lessFs
     if (less === null) {
       less = require('less');


### PR DESCRIPTION
The update to Less v4 made it so that inline JavaScript no longer worked. This is the simplest possible fix.

This is a feature that I used [to great effect](https://github.com/savetheclocktower/vibrant-ink-redux-syntax/blob/master/styles/utilities.less#L4) in my `vibrant-ink-redux` theme. I don't think it's a security risk for us because any package can already run arbitrary JavaScript, and inline JS in Less doesn't have special privileges or anything.

I wouldn't be shocked if I was the only person on Earth who used this feature in my Atom package, but we shouldn't break backward compatibility if it can be avoided.