### PR TITLE
Setup automated publishing to NPM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: NPM Publish
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+env:
+  NODE_VERSION: 16
+  NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - run: npm ci
+      - run: npm test
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish

--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ spec
 .travis.yml
 .npmignore
 npm-debug.log
+.github/

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "less-cache",
+  "name": "@pulsar-edit/less-cache",
   "version": "2.0.1",
   "description": "Less compile cache",
   "main": "./src/less-cache",


### PR DESCRIPTION
This PR configures automated publishing of this package to NPM under `@pulsar-edit/less-cache`.

This is the demo attempt at finalizing how we will do this organization wide.

The one none-standard thing here is that the secret we are using `NPM_PUBLISH_TOKEN` has been added on an organization level. 
Pros: This means we only have to manage and update a single token to handle all package publications. With that we could setup stricter expiration rules without demanding too much work to keep them valid.
Cons: This does reduce security by having the token be able to make changes cross all packages.

To mitigate the cons listed above, the token is only being allowed to selected repositories. Meaning we have to ensure that a repo is on it's list before being able to use the token. As of now this repository is the only one configured to have access to this token.

## How to actually publish

You may notice that I didn't opt to publish on commits or PRs, I thought it'd be too much of a headache to require any contributors to keep to specific semantics of their commit messages. Instead it seems to make more sense to me that we publish on a release being created. 

So if we want to publish a new version no code changes are needed, just create a new release on the releases page. This does require that you've also updated the version in the `package.json` of the repository.

@savetheclocktower